### PR TITLE
Fixed lowercase in map type switch.

### DIFF
--- a/src/JSONSchemaGenerator/Mappers/PropertyTypeMapper.php
+++ b/src/JSONSchemaGenerator/Mappers/PropertyTypeMapper.php
@@ -81,7 +81,7 @@ class PropertyTypeMapper
                 } else {
                     return PropertyTypeMapper::ARRAY_TYPE;
                 }
-            case 'NULL':
+            case 'null':
                 return PropertyTypeMapper::NULL_TYPE;
             case 'object':
                 return PropertyTypeMapper::OBJECT_TYPE;


### PR DESCRIPTION
In `src/JSONSchemaGenerator/Mappers/PropertyTypeMapper.php`, `public static function map($property)`, line 70 the swith has the reference in lowercase, but the case `null` is in upercase.